### PR TITLE
Fixes for 20110307 release

### DIFF
--- a/request.go
+++ b/request.go
@@ -216,8 +216,8 @@ func (r *Request) parseParams() (err os.Error) {
                 //read the data
                 data, _ := ioutil.ReadAll(part)
                 //check for the 'filename' param
-                v, ok := part.Header["Content-Disposition"]
-                if !ok {
+                v := part.Header.Get("Content-Disposition")
+                if v == "" {
                     continue
                 }
                 name := part.FormName()

--- a/web.go
+++ b/web.go
@@ -226,7 +226,7 @@ func (c *httpConn) Write(content []byte) (n int, err os.Error) {
 }
 
 func (c *httpConn) Close() {
-    rwc, buf, _ := c.conn.Hijack()
+	rwc, buf, _ := c.conn.(http.Hijacker).Hijack()
     if buf != nil {
         buf.Flush()
     }


### PR DESCRIPTION
Hi, please merge these simple fixes for the lastest release.
- request.go Use net/textproto MIMEHeader.Get()
  - web.go Type assert the http.ResponseWriter into a hijacker when calling close()
