### PR TITLE
fixes for release 2011-03-07.1 (incl. Cookie access) + fix to access filename of uploaded file

### DIFF
--- a/request.go
+++ b/request.go
@@ -38,6 +38,7 @@ type Request struct {
     Params     map[string]string
     ParamData  []byte
     Cookies    map[string]string
+    Cookie     []*http.Cookie
     Files      map[string]filedata
     RemoteAddr string
     RemotePort int
@@ -79,6 +80,7 @@ func newRequest(hr *http.Request, hc http.ResponseWriter) *Request {
         Referer:    hr.Referer,
         UserAgent:  hr.UserAgent,
         FullParams: hr.Form,
+        Cookie:     hr.Cookie,
         RemoteAddr: remoteAddr.IP.String(),
         RemotePort: remoteAddr.Port,
     }
@@ -253,30 +255,6 @@ func (r *Request) parseParams() (err os.Error) {
     }
 
     r.Params = flattenParams(r.FullParams)
-    return nil
-}
-
-func (r *Request) parseCookies() (err os.Error) {
-    if r.Cookies != nil {
-        return
-    }
-
-    r.Cookies = make(map[string]string)
-
-    if va, ok := r.Headers["Cookie"]; ok {
-        for _, v := range va {
-            cookies := strings.Split(v, ";", -1)
-            for _, cookie := range cookies {
-                cookie = strings.TrimSpace(cookie)
-                parts := strings.Split(cookie, "=", 2)
-                if len(parts) != 2 {
-                    continue
-                }
-                r.Cookies[parts[0]] = parts[1]
-            }
-        }
-    }
-
     return nil
 }
 


### PR DESCRIPTION
this contains gnanderson's fixes for 2011-03.07.1

to those fixes it adds:
- fixes to make GetSecureCookie work with 2011-03.07.1
  no longer parse Cookies ourselves; get them from http.Request.Header instead
- my fix for issue   https://github.com/hoisie/web.go/issues#issue/46
  make filename of uploaded file accessible again

Axel.
