### PR TITLE
Updated for weekly.2011-06-23 8864

### DIFF
--- a/request.go
+++ b/request.go
@@ -77,10 +77,10 @@ func newRequest(hr *http.Request, hc http.ResponseWriter) *Request {
         Body:       hr.Body,
         Close:      hr.Close,
         Host:       hr.Host,
-        Referer:    hr.Referer,
-        UserAgent:  hr.UserAgent,
+        Referer:    hr.Referer(),
+        UserAgent:  hr.UserAgent(),
         FullParams: hr.Form,
-        Cookie:     hr.Cookie,
+        Cookie:     hr.Cookies(),
         RemoteAddr: remoteAddr.IP.String(),
         RemotePort: remoteAddr.Port,
     }
@@ -181,7 +181,7 @@ func (r *Request) parseParams() (err os.Error) {
     switch r.Method {
     case "POST":
         if r.Body == nil {
-            return os.ErrorString("missing form body")
+            return os.NewError("missing form body")
         }
 
         ct := r.Headers.Get("Content-Type")


### PR DESCRIPTION
There's some left over "ErrorString" uses. -> changed to "NewError"
Changed hr.Referer -> hr.Referer()
Changed hr.UserAgent -> hr.UserAgent()
Changed hr.Cookie -> hr.Cookies()
