### PR TITLE
Don't break if port information isn't included in RemoteAddr

### DIFF
--- a/request.go
+++ b/request.go
@@ -63,7 +63,12 @@ func flattenParams(fullParams map[string][]string) map[string]string {
 
 func newRequest(hr *http.Request, hc http.ResponseWriter) *Request {
 
+    remoteAddrIP, remotePort := hr.RemoteAddr, 0
     remoteAddr, _ := net.ResolveTCPAddr("tcp", hr.RemoteAddr)
+    if remoteAddr != nil {
+        remoteAddrIP = remoteAddr.IP.String()
+        remotePort = remoteAddr.Port
+    }
 
     req := Request{
         Method:     hr.Method,
@@ -79,8 +84,8 @@ func newRequest(hr *http.Request, hc http.ResponseWriter) *Request {
         UserAgent:  hr.UserAgent(),
         FullParams: hr.Form,
         Cookie:     hr.Cookies(),
-        RemoteAddr: remoteAddr.IP.String(),
-        RemotePort: remoteAddr.Port,
+        RemoteAddr: remoteAddrIP,
+        RemotePort: remotePort,
     }
     return &req
 }


### PR DESCRIPTION
On Google App Engine, the port doesn't seem to be included in hr.RemoteAddr in newRequest. If that happens, port gets set to 0, and the IP to hr.RemoteAddr.

This might be a bug in App Engine or somewhere else, but at least with this change, it's possible to use web.go there.

I would have written a test, but it didn't seem easy to write one for this fix.
