### PR TITLE
Fixed routing for request-paths which contain an encoded slash (%2F)

### DIFF
--- a/web.go
+++ b/web.go
@@ -270,7 +270,7 @@ func (s *Server) routeHandler(req *http.Request, w ResponseWriter) {
 
     //log the request
     var logEntry bytes.Buffer
-    fmt.Fprintf(&logEntry, "\033[32;1m%s %s\033[0m", req.Method, requestPath)
+    fmt.Fprintf(&logEntry, "\033[32;1m%s %s\033[0m", req.Method, requestURI)
 
     //ignore errors from ParseForm because it's usually harmless.
     req.ParseForm()


### PR DESCRIPTION
Assuming you have set up a route like this:
    web.Get("/album/(._?)/(._?)/info", AlbumInfo)

Requests which contain an encoded slash (%2F) would now break this route, because the route handling is operating on the already url-decoded path. Consider this example:

http://.../album/Manowar+%2F+Friends/Into+Glory+Ride+%2F+Hail+to+England/info

The routing-handler would see this as: http://.../album/Manowar+/+Friends/Into+Glory+Ride+/+Hail+to+England/info

My fix uses the encoded requestURI to detect the right route and then unescapes the specified arguments only before calling the user-handler.
