### PR TITLE
Add ServeHTTP to serve as handler function (Google AppEngine Support)

### DIFF
--- a/web.go
+++ b/web.go
@@ -220,6 +220,10 @@ func (s *Server) ServeHTTP(c http.ResponseWriter, req *http.Request) {
     s.routeHandler(req, &w)
 }
 
+func (s *Server) Process(c http.ResponseWriter, req *http.Request) {
+    s.ServeHTTP(c, req)
+}
+
 //Calls a function with recover block
 func (s *Server) safelyCall(function reflect.Value, args []reflect.Value) (resp []reflect.Value, e interface{}) {
     defer func() {
@@ -453,8 +457,8 @@ func (s *Server) Close() {
 }
 
 //Serve the web server
-func ServeHTTP(c http.ResponseWriter, req *http.Request) {
-    mainServer.ServeHTTP(c, req)
+func Process(c http.ResponseWriter, req *http.Request) {
+    mainServer.Process(c, req)
 }
 
 //Stops the web server


### PR DESCRIPTION
This change support Google App Engine. #72

If you merge this change, minimal instruction to setup google appengine with web.go is follow:
#1. Setup web.go for google appengine

``` bash
$ git clone https://github.com/hoisie/web github.com/hoisie/web
$ rm -rf github.com/hoisie/web/.git
$ rm -rf github.com/hoisie/web/Readme.md
$ rm -rf github.com/hoisie/web/LICENSE
$ rm -rf github.com/hoisie/web/Makefile
$ rm -rf github.com/hoisie/web/examples
$ rm  -f github.com/hoisie/web/web_test.go
```
#2. Write you app

``` go
package mattnwebgo

import (
    "github.com/hoisie/web"
    "net/http"
)

func init() {
    web.Get("/", func() string {
        return "hello"
    })

    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
        web.ServeHTTP(w, r)
    })
}
```
#3. Add app.yaml

``` yaml
application: your-web-app
version: 1
runtime: go
api_version: go1

handlers:
- url: /static
  static_dir: static
- url: /.*
  script: _go_app
```
#4. Upload

``` bash
$ appcfg.py update .
```
# FAQ

If you want to use application context of appengine

``` go
package example

import (
    "appengine"
    "appengine/urlfetch"
    "github.com/hoisie/web.go"
    "http"
    "io/ioutil"
)

func init() {
    var c appengine.Context

    web.Get("/", func(ctx *web.Context) {
        client := urlfetch.Client(c)

        r, _, err := client.Get("http://www.getwebgo.com/")
        if err != nil {
            ctx.Abort(500, err.String())
            return
        }
        defer r.Body.Close()
        b, err := ioutil.ReadAll(r.Body)
        if err != nil {
            ctx.Abort(500, err.String())
            return
        }
        ctx.Write(b)
    })

    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
        c = appengine.NewContext(r)
        web.ServeHTTP(w, r)
    })
}
```
