### PR TITLE
Refactor Makefile to decouple from filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,6 @@
 GOFMT=gofmt -s -tabs=false -tabwidth=4
 
-GOFILES=\
-	fcgi.go\
-	helpers.go\
-	scgi.go\
-	server.go\
-	status.go\
-	web.go\
+GOFILES=$(wildcard *.go **/*.go)
 
 format:
 	${GOFMT} -w ${GOFILES}
-	${GOFMT} -w web_test.go
-	${GOFMT} -w examples/arcchallenge.go
-	${GOFMT} -w examples/cookie.go
-	${GOFMT} -w examples/hello.go
-	${GOFMT} -w examples/multipart.go
-	${GOFMT} -w examples/multiserver.go
-	${GOFMT} -w examples/params.go
-	${GOFMT} -w examples/logger.go
-	${GOFMT} -w examples/tls.go
-	${GOFMT} -w examples/streaming.go


### PR DESCRIPTION
There's no need to specify each file name, just use wildcards.
