### PR TITLE
Express.js-like middleware

### DIFF
--- a/server.go
+++ b/server.go
@@ -328,7 +328,7 @@ func (s *Server) logRequest(ctx Context, sTime time.Time) {
 func (s *Server) routeHandler(req *http.Request, w http.ResponseWriter) (unused *route) {
     routeHit := false
     requestPath := req.URL.Path
-    allContent := make([][]byte, 0)
+    allContent := make([][]byte, 0, 2)
     ctx := Context{req, map[string]string{}, s, w, false}
 
     finishResponse := func() {
@@ -364,8 +364,8 @@ func (s *Server) routeHandler(req *http.Request, w http.ResponseWriter) (unused 
         }
     }
 
-    defer s.logRequest(ctx, tm)
     defer finishResponse()
+    defer s.logRequest(ctx, tm)
 
     ctx.SetHeader("Date", webTime(tm), true)
 

--- a/web.go
+++ b/web.go
@@ -31,6 +31,7 @@ type Context struct {
     Params  map[string]string
     Server  *Server
     http.ResponseWriter
+    finished bool
 }
 
 // WriteString writes string data into the response object.
@@ -170,6 +171,14 @@ func (ctx *Context) GetSecureCookie(name string) (string, bool) {
     return "", false
 }
 
+func (ctx *Context) IsFinished() bool {
+    return ctx.finished
+}
+
+func (ctx *Context) Finish() {
+    ctx.finished = true
+}
+
 // small optimization: cache the context type instead of repeteadly calling reflect.Typeof
 var contextType reflect.Type
 
@@ -224,28 +233,28 @@ func Close() {
 }
 
 // Get adds a handler for the 'GET' http method in the main server.
-func Get(route string, handler interface{}) {
-    mainServer.Get(route, handler)
+func Get(route string, handlers ...interface{}) {
+    mainServer.addRoute(route, "GET", handlers...)
 }
 
 // Post adds a handler for the 'POST' http method in the main server.
-func Post(route string, handler interface{}) {
-    mainServer.addRoute(route, "POST", handler)
+func Post(route string, handlers ...interface{}) {
+    mainServer.addRoute(route, "POST", handlers...)
 }
 
 // Put adds a handler for the 'PUT' http method in the main server.
-func Put(route string, handler interface{}) {
-    mainServer.addRoute(route, "PUT", handler)
+func Put(route string, handlers ...interface{}) {
+    mainServer.addRoute(route, "PUT", handlers...)
 }
 
 // Delete adds a handler for the 'DELETE' http method in the main server.
-func Delete(route string, handler interface{}) {
-    mainServer.addRoute(route, "DELETE", handler)
+func Delete(route string, handlers ...interface{}) {
+    mainServer.addRoute(route, "DELETE", handlers...)
 }
 
 // Match adds a handler for an arbitrary http method in the main server.
-func Match(method string, route string, handler interface{}) {
-    mainServer.addRoute(route, method, handler)
+func Match(method string, route string, handlers ...interface{}) {
+    mainServer.addRoute(route, method, handlers...)
 }
 
 //Adds a custom handler. Only for webserver mode. Will have no effect when running as FCGI or SCGI.

--- a/web.go
+++ b/web.go
@@ -267,6 +267,10 @@ func Websocket(route string, httpHandler websocket.Handler) {
     mainServer.Websocket(route, httpHandler)
 }
 
+func Middleware(handler interface{}) {
+    mainServer.Middleware(handler)
+}
+
 // SetLogger sets the logger for the main server.
 func SetLogger(logger *log.Logger) {
     mainServer.Logger = logger

--- a/web_test.go
+++ b/web_test.go
@@ -215,6 +215,32 @@ func init() {
         }
         return user + pass
     })
+
+    // Test for multiple functions in a call. f1, f2 and f3 should be hit, f4
+    // should be skipped since f3 finishes. Thus the overall response
+    // should be an HTTP 401 (unauthorized) with a body "response1\nresponse3"
+    f1 := func(ctx *Context) string {
+        ctx.Unauthorized()
+        return "response1\n"
+    }
+
+    f2 := func(ctx *Context) []string {
+        return nil
+    }
+
+    f3 := func(ctx *Context) string {
+        ctx.Finish()
+        return "response3"
+    }
+
+    f4 := func(ctx *Context) string {
+        return "response4"
+    }
+
+    Get("/multifunc", f1, f2, f3, f4)
+
+    // Test for no handler specification. Should return a 404.
+    Get("/nofunc")    
 }
 
 var tests = []Test{
@@ -248,6 +274,8 @@ var tests = []Test{
     {"POST", "/parsejson", map[string][]string{"Content-Type": {"application/json"}}, `{"a":"hello", "b":"world"}`, 200, "hello world"},
     //{"GET", "/testenv", "", 200, "hello world"},
     {"GET", "/authorization", map[string][]string{"Authorization": {BuildBasicAuthCredentials("foo", "bar")}}, "", 200, "foobar"},
+    {"GET", "/multifunc", nil, "", 401, "response1\nresponse3"},
+    {"GET", "/nofunc", nil, "", 404, "Page not found"},
 }
 
 func buildTestRequest(method string, path string, body string, headers map[string][]string, cookies []*http.Cookie) *http.Request {


### PR DESCRIPTION
This adds support for express.js-like middleware. With this patch, multiple functions can be called for any given endpoint, which allows you add functionality in a compositional manner.

You can specify global middleware that is called for all requests:

```
web.Middleware(gzip)
web.Middleware(basicAuth)

// This endpoint will now call the following functions in order: gzip,
// basicAuth, sayHello
web.Get("/", sayHello)
```

And you can specify middleware on a per-endpoint basis:

```
// Functionally the same as the above, although other endpoints specified
// will not have gzip and basicAuth called now.
web.Get("/", gzip, basicAuth, sayHello)
```

Not every function in the chain has to be called. A function can "bail" the request and circumvent the execution of further middleware by calling `ctx.Finish()`. e.g. if `basicAuth` in the above examples set some headers and called `ctx.Finish()` because the authentication failed, `sayHello` will not be called.

Unit tests have been added as well, although I'm not confident that this patch is bug-free. A second pair of eyes would help greatly since I'm not too familiar with this codebase, especially the altered logic in `routeHandler`.
