### PR TITLE
remove coloring in log output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,11 +18,11 @@ Make sure you have the a working Go environment. See the [install instructions](
 
 To install web.go, simply run:
 
-    go get github.com/hoisie/web
+    go get github.com/shivakumargn/web
 
 To compile it from source:
 
-    git clone git://github.com/hoisie/web.git
+    git clone git://github.com/shivakumargn/web.git
     cd web && go build
 
 ## Example
@@ -30,7 +30,7 @@ To compile it from source:
 package main
     
 import (
-    "github.com/hoisie/web"
+    "github.com/shivakumargn/web"
 )
     
 func hello(val string) string { return "hello " + val } 
@@ -55,7 +55,7 @@ Route handlers may contain a pointer to web.Context as their first parameter. Th
 package main
 
 import (
-    "github.com/hoisie/web"
+    "github.com/shivakumargn/web"
 )
     
 func hello(ctx *web.Context, val string) { 
@@ -75,14 +75,8 @@ In this example, if you visit `http://localhost:9999/?a=1&b=2`, you'll see the f
     a 1
     b 2
 
-## Documentation
-
-API docs are hosted at http://webgo.io
-
-If you use web.go, I'd greatly appreciate a quick message about what you're building with it. This will help me get a sense of usage patterns, and helps me focus development efforts on features that people will actually use. 
-
 ## About
 
-web.go was written by [Michael Hoisie](http://hoisie.com). 
+This web.go is adapted from github.com/hoisie/web to work with gorilla/mux. 
 
 

--- a/helpers.go
+++ b/helpers.go
@@ -93,8 +93,8 @@ func NewCookie(name string, value string, age int64) *http.Cookie {
 
 // GetBasicAuth is a helper method of *Context that returns the decoded
 // user and password from the *Context's authorization header
-func (ctx *Context) GetBasicAuth() (string, string, error) {
-    authHeader := ctx.Request.Header["Authorization"][0]
+func GetBasicAuth(r *http.Request) (string, string, error) {
+	authHeader := r.Header["Authorization"][0]
     authString := strings.Split(string(authHeader), " ")
     if authString[0] != "Basic" {
         return "", "", errors.New("Not Basic Authentication")

--- a/scgi.go
+++ b/scgi.go
@@ -143,7 +143,7 @@ func (s *Server) handleScgiRequest(fd io.ReadWriteCloser) {
         s.Logger.Println("SCGI error: %q", err.Error())
     }
     sc := scgiConn{fd, req, make(map[string][]string), false}
-    s.routeHandler(req, &sc)
+	//s.routeHandler(req, &sc)	//TODO: need mux based implementation
     sc.finishRequest()
     fd.Close()
 }

--- a/server.go
+++ b/server.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -76,63 +75,30 @@ type route struct {
 }
 
 func (s *Server) addRoute(r string, method string, handler interface{}) {
-	/*
-		cr, err := regexp.Compile(r)
-		if err != nil {
-			s.Logger.Printf("Error in route regex %q\n", r)
-			return
-		}
-
-		switch handler.(type) {
-		case http.Handler:
-			s.routes = append(s.routes, route{r: r, cr: cr, method: method, httpHandler: handler.(http.Handler)})
-		case reflect.Value:
-			fv := handler.(reflect.Value)
-			s.routes = append(s.routes, route{r: r, cr: cr, method: method, handler: fv})
-		default:
-			fv := reflect.ValueOf(handler)
-			s.routes = append(s.routes, route{r: r, cr: cr, method: method, handler: fv})
-		}
-
-	*/
 	if s.muxrouter == nil {
 		s.muxrouter = mux.NewRouter()
 	}
 	switch f := handler.(type) {
 	case func(http.ResponseWriter, *http.Request):
 		s.muxrouter.NewRoute().Path(r).HandlerFunc(f).Methods(method)
-	case func(*Context, string):
-		log.Println("ERROR: ", reflect.TypeOf(handler))
-		panic("ctx - webio signature not supported")
-		s.muxrouter.NewRoute().Path(r).HandlerFunc(webio_handler(s, f)).Methods(method)
 	default:
 		log.Println("ERROR: ", reflect.TypeOf(handler))
 		panic("incorrect handler signature: ")
 	}
 }
 
+/*
 func webio_handler(s *Server, f1 func(*Context, string)) func(http.ResponseWriter, *http.Request) {
 	f2 := func(w http.ResponseWriter, r *http.Request) {
 		s.ServeHTTP(w, r)
 	}
 	return f2
 }
+*/
 
 // ServeHTTP is the interface method for Go's http server package
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Println("DEBUG: ServeHTTP ->")
-	defer log.Println("DEBUG: ServeHTTP <-")
-	//defer context.Clear(r)
-	//s.Process(w, r)
 	s.muxrouter.ServeHTTP(w, r)
-}
-
-// Process invokes the routing system for server s
-func (s *Server) Process(c http.ResponseWriter, req *http.Request) {
-	route := s.routeHandler(req, c)
-	if route != nil {
-		route.httpHandler.ServeHTTP(c, req)
-	}
 }
 
 // Get adds a handler for the 'GET' http method for server s.
@@ -189,7 +155,7 @@ func (s *Server) Run(addr string) {
 	}
 	s.muxrouter.Handle("/", s)
 
-	s.Logger.Printf("web.go serving %s\n", addr)
+	s.Logger.Printf("serving %s\n", addr)
 
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -208,14 +174,14 @@ func (s *Server) Shutdown() {
 // RunFcgi starts the web application and serves FastCGI requests for s.
 func (s *Server) RunFcgi(addr string) {
 	s.initServer()
-	s.Logger.Printf("web.go serving fcgi %s\n", addr)
+	s.Logger.Printf("serving fcgi %s\n", addr)
 	s.listenAndServeFcgi(addr)
 }
 
 // RunScgi starts the web application and serves SCGI requests for s.
 func (s *Server) RunScgi(addr string) {
 	s.initServer()
-	s.Logger.Printf("web.go serving scgi %s\n", addr)
+	s.Logger.Printf("serving scgi %s\n", addr)
 	s.listenAndServeScgi(addr)
 }
 
@@ -224,6 +190,9 @@ func (s *Server) RunTLS(addr string, config *tls.Config) error {
 	s.initServer()
 	mux := http.NewServeMux()
 	mux.Handle("/", s)
+	
+	s.Logger.Printf("serving %s\n", addr)
+	
 	l, err := tls.Listen("tcp", addr, config)
 	if err != nil {
 		log.Fatal("Listen:", err)
@@ -265,27 +234,6 @@ func (s *Server) safelyCall(function reflect.Value, args []reflect.Value) (resp 
 	return function.Call(args), nil
 }
 
-// requiresContext determines whether 'handlerType' contains
-// an argument to 'web.Ctx' as its first argument
-func requiresContext(handlerType reflect.Type) bool {
-	//if the method doesn't take arguments, no
-	if handlerType.NumIn() == 0 {
-		return false
-	}
-
-	//if the first argument is not a pointer, no
-	a0 := handlerType.In(0)
-	if a0.Kind() != reflect.Ptr {
-		return false
-	}
-	//if the first argument is a context, yes
-	if a0.Elem() == contextType {
-		return true
-	}
-
-	return false
-}
-
 // tryServingFile attempts to serve a static file, and returns
 // whether or not the operation is successful.
 // It checks the following directories for the file, in order:
@@ -312,10 +260,10 @@ func (s *Server) tryServingFile(name string, req *http.Request, w http.ResponseW
 	return false
 }
 
-func (s *Server) logRequest(ctx Context, sTime time.Time) {
+func (s *Server) logRequest(r *http.Request, sTime time.Time) {
 	//log the request
 	var logEntry bytes.Buffer
-	req := ctx.Request
+	req := r
 	requestPath := req.URL.Path
 
 	duration := time.Now().Sub(sTime)
@@ -332,120 +280,13 @@ func (s *Server) logRequest(ctx Context, sTime time.Time) {
 
 	fmt.Fprintf(&logEntry, "%s - %s %s - %v", client, req.Method, requestPath, duration)
 
+	/*
 	if len(ctx.Params) > 0 {
 		fmt.Fprintf(&logEntry, " - Params: %v\n", ctx.Params)
 	}
+	*/
 
-	ctx.Server.Logger.Print(logEntry.String())
-
-}
-
-// the main route handler in web.go
-// Tries to handle the given request.
-// Finds the route matching the request, and execute the callback associated
-// with it.  In case of custom http handlers, this function returns an "unused"
-// route. The caller is then responsible for calling the httpHandler associated
-// with the returned route.
-func (s *Server) routeHandler(req *http.Request, w http.ResponseWriter) (unused *route) {
-	requestPath := req.URL.Path
-	ctx := Context{req, map[string]string{}, s, w}
-
-	//set some default headers
-	ctx.SetHeader("Server", "web.go", true)
-	tm := time.Now().UTC()
-
-	//ignore errors from ParseForm because it's usually harmless.
-	req.ParseForm()
-	if len(req.Form) > 0 {
-		for k, v := range req.Form {
-			ctx.Params[k] = v[0]
-		}
-	}
-
-	defer s.logRequest(ctx, tm)
-
-	ctx.SetHeader("Date", webTime(tm), true)
-
-	if req.Method == "GET" || req.Method == "HEAD" {
-		if s.tryServingFile(requestPath, req, w) {
-			return
-		}
-	}
-
-	//Set the default content-type
-	ctx.SetHeader("Content-Type", "text/html; charset=utf-8", true)
-
-	for i := 0; i < len(s.routes); i++ {
-		route := s.routes[i]
-		cr := route.cr
-		//if the methods don't match, skip this handler (except HEAD can be used in place of GET)
-		if req.Method != route.method && !(req.Method == "HEAD" && route.method == "GET") {
-			continue
-		}
-
-		if !cr.MatchString(requestPath) {
-			continue
-		}
-		match := cr.FindStringSubmatch(requestPath)
-
-		if len(match[0]) != len(requestPath) {
-			continue
-		}
-		if len(match) == 1 { // support handling of URL when there is no trailing "/"
-			match = append(match, "")
-		}
-
-		if route.httpHandler != nil {
-			unused = &route
-			// We can not handle custom http handlers here, give back to the caller.
-			return
-		}
-
-		var args []reflect.Value
-		handlerType := route.handler.Type()
-		if requiresContext(handlerType) {
-			args = append(args, reflect.ValueOf(&ctx))
-		}
-		for _, arg := range match[1:] {
-			args = append(args, reflect.ValueOf(arg))
-		}
-
-		ret, err := s.safelyCall(route.handler, args)
-		if err != nil {
-			//there was an error or panic while calling the handler
-			ctx.Abort(500, "Server Error")
-		}
-		if len(ret) == 0 {
-			return
-		}
-
-		sval := ret[0]
-
-		var content []byte
-
-		if sval.Kind() == reflect.String {
-			content = []byte(sval.String())
-		} else if sval.Kind() == reflect.Slice && sval.Type().Elem().Kind() == reflect.Uint8 {
-			content = sval.Interface().([]byte)
-		}
-		ctx.SetHeader("Content-Length", strconv.Itoa(len(content)), true)
-		_, err = ctx.ResponseWriter.Write(content)
-		if err != nil {
-			ctx.Server.Logger.Println("Error during write: ", err)
-		}
-		return
-	}
-
-	// try serving index.html or index.htm
-	if req.Method == "GET" || req.Method == "HEAD" {
-		if s.tryServingFile(path.Join(requestPath, "index.html"), req, w) {
-			return
-		} else if s.tryServingFile(path.Join(requestPath, "index.htm"), req, w) {
-			return
-		}
-	}
-	ctx.Abort(404, "Page not found")
-	return
+	s.Logger.Print(logEntry.String())
 }
 
 // SetLogger sets the logger for server s

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"path"
 	"reflect"
-    "regexp"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -200,6 +200,11 @@ func (s *Server) Run(addr string) {
 	s.l.Close()
 }
 
+func (s *Server) Shutdown() {
+	s.l.Close()
+	//TODO: Existing connections as well must be closed gracefully
+}
+
 // RunFcgi starts the web application and serves FastCGI requests for s.
 func (s *Server) RunFcgi(addr string) {
 	s.initServer()
@@ -263,22 +268,22 @@ func (s *Server) safelyCall(function reflect.Value, args []reflect.Value) (resp 
 // requiresContext determines whether 'handlerType' contains
 // an argument to 'web.Ctx' as its first argument
 func requiresContext(handlerType reflect.Type) bool {
-    //if the method doesn't take arguments, no
-    if handlerType.NumIn() == 0 {
-        return false
-    }
+	//if the method doesn't take arguments, no
+	if handlerType.NumIn() == 0 {
+		return false
+	}
 
-    //if the first argument is not a pointer, no
-    a0 := handlerType.In(0)
-    if a0.Kind() != reflect.Ptr {
-        return false
-    }
-    //if the first argument is a context, yes
-    if a0.Elem() == contextType {
-        return true
-    }
+	//if the first argument is not a pointer, no
+	a0 := handlerType.In(0)
+	if a0.Kind() != reflect.Ptr {
+		return false
+	}
+	//if the first argument is a context, yes
+	if a0.Elem() == contextType {
+		return true
+	}
 
-    return false
+	return false
 }
 
 // tryServingFile attempts to serve a static file, and returns

--- a/server.go
+++ b/server.go
@@ -1,220 +1,263 @@
 package web
 
 import (
-    "bytes"
-    "code.google.com/p/go.net/websocket"
-    "crypto/tls"
-    "fmt"
-    "log"
-    "net"
-    "net/http"
-    "net/http/pprof"
-    "os"
-    "path"
-    "reflect"
+	"bytes"
+	"code.google.com/p/go.net/websocket"
+	"crypto/tls"
+	"fmt"
+	"github.com/gorilla/mux"
+	"log"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"path"
+	"reflect"
     "regexp"
-    "runtime"
-    "strconv"
-    "strings"
-    "time"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // ServerConfig is configuration for server objects.
 type ServerConfig struct {
-    StaticDir    string
-    Addr         string
-    Port         int
-    CookieSecret string
-    RecoverPanic bool
-    Profiler     bool
+	StaticDir    string
+	Addr         string
+	Port         int
+	CookieSecret string
+	RecoverPanic bool
+	Profiler     bool
 }
 
 // Server represents a web.go server.
 type Server struct {
-    Config *ServerConfig
-    routes []route
-    Logger *log.Logger
-    Env    map[string]interface{}
-    //save the listener so it can be closed
-    l   net.Listener
+	Config    *ServerConfig
+	routes    []route
+	muxrouter *mux.Router
+	Logger    *log.Logger
+	Env       map[string]interface{}
+	//save the listener so it can be closed
+	l net.Listener
 }
 
 func NewServer() *Server {
-    return &Server{
-        Config: Config,
-        Logger: log.New(os.Stdout, "", log.Ldate|log.Ltime),
-        Env:    map[string]interface{}{},
-    }
+	return &Server{
+		Config:    Config,
+		muxrouter: mux.NewRouter(),
+		Logger:    log.New(os.Stdout, "", log.Ldate|log.Ltime),
+		Env:       map[string]interface{}{},
+	}
 }
 
 func (s *Server) initServer() {
-    if s.Config == nil {
-        s.Config = &ServerConfig{}
-    }
+	if s.Config == nil {
+		s.Config = &ServerConfig{}
+	}
 
-    if s.Logger == nil {
-        s.Logger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
-    }
+	if s.Logger == nil {
+		s.Logger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
+	}
+}
+
+func (s *Server) Router() *mux.Router {
+	if s.muxrouter == nil {
+		s.muxrouter = mux.NewRouter()
+	}
+	return s.muxrouter
 }
 
 type route struct {
-    r           string
-    cr          *regexp.Regexp
-    method      string
-    handler     reflect.Value
-    httpHandler http.Handler
+	r           string
+	cr          *regexp.Regexp
+	method      string
+	handler     reflect.Value
+	httpHandler http.Handler
 }
 
 func (s *Server) addRoute(r string, method string, handler interface{}) {
-    cr, err := regexp.Compile(r)
-    if err != nil {
-        s.Logger.Printf("Error in route regex %q\n", r)
-        return
-    }
+	/*
+		cr, err := regexp.Compile(r)
+		if err != nil {
+			s.Logger.Printf("Error in route regex %q\n", r)
+			return
+		}
 
-    switch handler.(type) {
-    case http.Handler:
-        s.routes = append(s.routes, route{r: r, cr: cr, method: method, httpHandler: handler.(http.Handler)})
-    case reflect.Value:
-        fv := handler.(reflect.Value)
-        s.routes = append(s.routes, route{r: r, cr: cr, method: method, handler: fv})
-    default:
-        fv := reflect.ValueOf(handler)
-        s.routes = append(s.routes, route{r: r, cr: cr, method: method, handler: fv})
-    }
+		switch handler.(type) {
+		case http.Handler:
+			s.routes = append(s.routes, route{r: r, cr: cr, method: method, httpHandler: handler.(http.Handler)})
+		case reflect.Value:
+			fv := handler.(reflect.Value)
+			s.routes = append(s.routes, route{r: r, cr: cr, method: method, handler: fv})
+		default:
+			fv := reflect.ValueOf(handler)
+			s.routes = append(s.routes, route{r: r, cr: cr, method: method, handler: fv})
+		}
+
+	*/
+	if s.muxrouter == nil {
+		s.muxrouter = mux.NewRouter()
+	}
+	switch f := handler.(type) {
+	case func(http.ResponseWriter, *http.Request):
+		s.muxrouter.NewRoute().Path(r).HandlerFunc(f).Methods(method)
+	case func(*Context, string):
+		log.Println("ERROR: ", reflect.TypeOf(handler))
+		panic("ctx - webio signature not supported")
+		s.muxrouter.NewRoute().Path(r).HandlerFunc(webio_handler(s, f)).Methods(method)
+	default:
+		log.Println("ERROR: ", reflect.TypeOf(handler))
+		panic("incorrect handler signature: ")
+	}
+}
+
+func webio_handler(s *Server, f1 func(*Context, string)) func(http.ResponseWriter, *http.Request) {
+	f2 := func(w http.ResponseWriter, r *http.Request) {
+		s.ServeHTTP(w, r)
+	}
+	return f2
 }
 
 // ServeHTTP is the interface method for Go's http server package
-func (s *Server) ServeHTTP(c http.ResponseWriter, req *http.Request) {
-    s.Process(c, req)
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Println("DEBUG: ServeHTTP ->")
+	defer log.Println("DEBUG: ServeHTTP <-")
+	//defer context.Clear(r)
+	//s.Process(w, r)
+	s.muxrouter.ServeHTTP(w, r)
 }
 
 // Process invokes the routing system for server s
 func (s *Server) Process(c http.ResponseWriter, req *http.Request) {
-    route := s.routeHandler(req, c)
-    if route != nil {
-        route.httpHandler.ServeHTTP(c, req)
-    }
+	route := s.routeHandler(req, c)
+	if route != nil {
+		route.httpHandler.ServeHTTP(c, req)
+	}
 }
 
 // Get adds a handler for the 'GET' http method for server s.
 func (s *Server) Get(route string, handler interface{}) {
-    s.addRoute(route, "GET", handler)
+	s.addRoute(route, "GET", handler)
 }
 
 // Post adds a handler for the 'POST' http method for server s.
 func (s *Server) Post(route string, handler interface{}) {
-    s.addRoute(route, "POST", handler)
+	s.addRoute(route, "POST", handler)
 }
 
 // Put adds a handler for the 'PUT' http method for server s.
 func (s *Server) Put(route string, handler interface{}) {
-    s.addRoute(route, "PUT", handler)
+	s.addRoute(route, "PUT", handler)
 }
 
 // Delete adds a handler for the 'DELETE' http method for server s.
 func (s *Server) Delete(route string, handler interface{}) {
-    s.addRoute(route, "DELETE", handler)
+	s.addRoute(route, "DELETE", handler)
 }
 
 // Match adds a handler for an arbitrary http method for server s.
 func (s *Server) Match(method string, route string, handler interface{}) {
-    s.addRoute(route, method, handler)
+	s.addRoute(route, method, handler)
 }
 
 //Adds a custom handler. Only for webserver mode. Will have no effect when running as FCGI or SCGI.
 func (s *Server) Handler(route string, method string, httpHandler http.Handler) {
-    s.addRoute(route, method, httpHandler)
+	s.addRoute(route, method, httpHandler)
 }
 
 //Adds a handler for websockets. Only for webserver mode. Will have no effect when running as FCGI or SCGI.
 func (s *Server) Websocket(route string, httpHandler websocket.Handler) {
-    s.addRoute(route, "GET", httpHandler)
+	s.addRoute(route, "GET", httpHandler)
 }
 
 // Run starts the web application and serves HTTP requests for s
 func (s *Server) Run(addr string) {
-    s.initServer()
+	s.initServer()
 
-    mux := http.NewServeMux()
-    if s.Config.Profiler {
-        mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-        mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-        mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-        mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-        mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-    }
-    mux.Handle("/", s)
+	if s.muxrouter == nil {
+		s.muxrouter = mux.NewRouter()
+	}
+	if s.Config.Profiler {
+		s.muxrouter.Handle("/debug/pprof", http.HandlerFunc(pprof.Index))
+		s.muxrouter.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		s.muxrouter.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		s.muxrouter.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		s.muxrouter.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+		s.muxrouter.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+		s.muxrouter.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+		s.muxrouter.Handle("/debug/pprof/block", pprof.Handler("block"))
+	}
+	s.muxrouter.Handle("/", s)
 
-    s.Logger.Printf("web.go serving %s\n", addr)
+	s.Logger.Printf("web.go serving %s\n", addr)
 
-    l, err := net.Listen("tcp", addr)
-    if err != nil {
-        log.Fatal("ListenAndServe:", err)
-    }
-    s.l = l
-    err = http.Serve(s.l, mux)
-    s.l.Close()
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal("ListenAndServe:", err)
+	}
+	s.l = l
+	err = http.Serve(s.l, s.muxrouter)
+	s.l.Close()
 }
 
 // RunFcgi starts the web application and serves FastCGI requests for s.
 func (s *Server) RunFcgi(addr string) {
-    s.initServer()
-    s.Logger.Printf("web.go serving fcgi %s\n", addr)
-    s.listenAndServeFcgi(addr)
+	s.initServer()
+	s.Logger.Printf("web.go serving fcgi %s\n", addr)
+	s.listenAndServeFcgi(addr)
 }
 
 // RunScgi starts the web application and serves SCGI requests for s.
 func (s *Server) RunScgi(addr string) {
-    s.initServer()
-    s.Logger.Printf("web.go serving scgi %s\n", addr)
-    s.listenAndServeScgi(addr)
+	s.initServer()
+	s.Logger.Printf("web.go serving scgi %s\n", addr)
+	s.listenAndServeScgi(addr)
 }
 
 // RunTLS starts the web application and serves HTTPS requests for s.
 func (s *Server) RunTLS(addr string, config *tls.Config) error {
-    s.initServer()
-    mux := http.NewServeMux()
-    mux.Handle("/", s)
-    l, err := tls.Listen("tcp", addr, config)
-    if err != nil {
-        log.Fatal("Listen:", err)
-        return err
-    }
+	s.initServer()
+	mux := http.NewServeMux()
+	mux.Handle("/", s)
+	l, err := tls.Listen("tcp", addr, config)
+	if err != nil {
+		log.Fatal("Listen:", err)
+		return err
+	}
 
-    s.l = l
-    return http.Serve(s.l, mux)
+	s.l = l
+	return http.Serve(s.l, mux)
 }
 
 // Close stops server s.
 func (s *Server) Close() {
-    if s.l != nil {
-        s.l.Close()
-    }
+	if s.l != nil {
+		s.l.Close()
+	}
 }
 
 // safelyCall invokes `function` in recover block
 func (s *Server) safelyCall(function reflect.Value, args []reflect.Value) (resp []reflect.Value, e interface{}) {
-    defer func() {
-        if err := recover(); err != nil {
-            if !s.Config.RecoverPanic {
-                // go back to panic
-                panic(err)
-            } else {
-                e = err
-                resp = nil
-                s.Logger.Println("Handler crashed with error", err)
-                for i := 1; ; i += 1 {
-                    _, file, line, ok := runtime.Caller(i)
-                    if !ok {
-                        break
-                    }
-                    s.Logger.Println(file, line)
-                }
-            }
-        }
-    }()
-    return function.Call(args), nil
+	defer func() {
+		if err := recover(); err != nil {
+			if !s.Config.RecoverPanic {
+				// go back to panic
+				panic(err)
+			} else {
+				e = err
+				resp = nil
+				s.Logger.Println("Handler crashed with error", err)
+				for i := 1; ; i += 1 {
+					_, file, line, ok := runtime.Caller(i)
+					if !ok {
+						break
+					}
+					s.Logger.Println(file, line)
+				}
+			}
+		}
+	}()
+	return function.Call(args), nil
 }
 
 // requiresContext determines whether 'handlerType' contains
@@ -245,50 +288,50 @@ func requiresContext(handlerType reflect.Type) bool {
 // 2) The 'static' directory in the parent directory of the executable.
 // 3) The 'static' directory in the current working directory
 func (s *Server) tryServingFile(name string, req *http.Request, w http.ResponseWriter) bool {
-    //try to serve a static file
-    if s.Config.StaticDir != "" {
-        staticFile := path.Join(s.Config.StaticDir, name)
-        if fileExists(staticFile) {
-            http.ServeFile(w, req, staticFile)
-            return true
-        }
-    } else {
-        for _, staticDir := range defaultStaticDirs {
-            staticFile := path.Join(staticDir, name)
-            if fileExists(staticFile) {
-                http.ServeFile(w, req, staticFile)
-                return true
-            }
-        }
-    }
-    return false
+	//try to serve a static file
+	if s.Config.StaticDir != "" {
+		staticFile := path.Join(s.Config.StaticDir, name)
+		if fileExists(staticFile) {
+			http.ServeFile(w, req, staticFile)
+			return true
+		}
+	} else {
+		for _, staticDir := range defaultStaticDirs {
+			staticFile := path.Join(staticDir, name)
+			if fileExists(staticFile) {
+				http.ServeFile(w, req, staticFile)
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (s *Server) logRequest(ctx Context, sTime time.Time) {
-    //log the request
-    var logEntry bytes.Buffer
-    req := ctx.Request
-    requestPath := req.URL.Path
+	//log the request
+	var logEntry bytes.Buffer
+	req := ctx.Request
+	requestPath := req.URL.Path
 
-    duration := time.Now().Sub(sTime)
-    var client string
+	duration := time.Now().Sub(sTime)
+	var client string
 
-    // We suppose RemoteAddr is of the form Ip:Port as specified in the Request
-    // documentation at http://golang.org/pkg/net/http/#Request
-    pos := strings.LastIndex(req.RemoteAddr, ":")
-    if pos > 0 {
-        client = req.RemoteAddr[0:pos]
-    } else {
-        client = req.RemoteAddr
-    }
+	// We suppose RemoteAddr is of the form Ip:Port as specified in the Request
+	// documentation at http://golang.org/pkg/net/http/#Request
+	pos := strings.LastIndex(req.RemoteAddr, ":")
+	if pos > 0 {
+		client = req.RemoteAddr[0:pos]
+	} else {
+		client = req.RemoteAddr
+	}
 
-    fmt.Fprintf(&logEntry, "%s - %s %s - %v", client, req.Method, requestPath, duration)
+	fmt.Fprintf(&logEntry, "%s - %s %s - %v", client, req.Method, requestPath, duration)
 
-    if len(ctx.Params) > 0 {
-        fmt.Fprintf(&logEntry, " - Params: %v\n", ctx.Params)
-    }
+	if len(ctx.Params) > 0 {
+		fmt.Fprintf(&logEntry, " - Params: %v\n", ctx.Params)
+	}
 
-    ctx.Server.Logger.Print(logEntry.String())
+	ctx.Server.Logger.Print(logEntry.String())
 
 }
 
@@ -299,105 +342,108 @@ func (s *Server) logRequest(ctx Context, sTime time.Time) {
 // route. The caller is then responsible for calling the httpHandler associated
 // with the returned route.
 func (s *Server) routeHandler(req *http.Request, w http.ResponseWriter) (unused *route) {
-    requestPath := req.URL.Path
-    ctx := Context{req, map[string]string{}, s, w}
+	requestPath := req.URL.Path
+	ctx := Context{req, map[string]string{}, s, w}
 
-    //set some default headers
-    ctx.SetHeader("Server", "web.go", true)
-    tm := time.Now().UTC()
+	//set some default headers
+	ctx.SetHeader("Server", "web.go", true)
+	tm := time.Now().UTC()
 
-    //ignore errors from ParseForm because it's usually harmless.
-    req.ParseForm()
-    if len(req.Form) > 0 {
-        for k, v := range req.Form {
-            ctx.Params[k] = v[0]
-        }
-    }
+	//ignore errors from ParseForm because it's usually harmless.
+	req.ParseForm()
+	if len(req.Form) > 0 {
+		for k, v := range req.Form {
+			ctx.Params[k] = v[0]
+		}
+	}
 
-    defer s.logRequest(ctx, tm)
+	defer s.logRequest(ctx, tm)
 
-    ctx.SetHeader("Date", webTime(tm), true)
+	ctx.SetHeader("Date", webTime(tm), true)
 
-    if req.Method == "GET" || req.Method == "HEAD" {
-        if s.tryServingFile(requestPath, req, w) {
-            return
-        }
-    }
+	if req.Method == "GET" || req.Method == "HEAD" {
+		if s.tryServingFile(requestPath, req, w) {
+			return
+		}
+	}
 
-    //Set the default content-type
-    ctx.SetHeader("Content-Type", "text/html; charset=utf-8", true)
+	//Set the default content-type
+	ctx.SetHeader("Content-Type", "text/html; charset=utf-8", true)
 
-    for i := 0; i < len(s.routes); i++ {
-        route := s.routes[i]
-        cr := route.cr
-        //if the methods don't match, skip this handler (except HEAD can be used in place of GET)
-        if req.Method != route.method && !(req.Method == "HEAD" && route.method == "GET") {
-            continue
-        }
+	for i := 0; i < len(s.routes); i++ {
+		route := s.routes[i]
+		cr := route.cr
+		//if the methods don't match, skip this handler (except HEAD can be used in place of GET)
+		if req.Method != route.method && !(req.Method == "HEAD" && route.method == "GET") {
+			continue
+		}
 
-        if !cr.MatchString(requestPath) {
-            continue
-        }
-        match := cr.FindStringSubmatch(requestPath)
+		if !cr.MatchString(requestPath) {
+			continue
+		}
+		match := cr.FindStringSubmatch(requestPath)
 
-        if len(match[0]) != len(requestPath) {
-            continue
-        }
+		if len(match[0]) != len(requestPath) {
+			continue
+		}
+		if len(match) == 1 { // support handling of URL when there is no trailing "/"
+			match = append(match, "")
+		}
 
-        if route.httpHandler != nil {
-            unused = &route
-            // We can not handle custom http handlers here, give back to the caller.
-            return
-        }
+		if route.httpHandler != nil {
+			unused = &route
+			// We can not handle custom http handlers here, give back to the caller.
+			return
+		}
 
-        var args []reflect.Value
-        handlerType := route.handler.Type()
-        if requiresContext(handlerType) {
-            args = append(args, reflect.ValueOf(&ctx))
-        }
-        for _, arg := range match[1:] {
-            args = append(args, reflect.ValueOf(arg))
-        }
+		var args []reflect.Value
+		handlerType := route.handler.Type()
+		if requiresContext(handlerType) {
+			args = append(args, reflect.ValueOf(&ctx))
+		}
+		for _, arg := range match[1:] {
+			args = append(args, reflect.ValueOf(arg))
+		}
 
-        ret, err := s.safelyCall(route.handler, args)
-        if err != nil {
-            //there was an error or panic while calling the handler
-            ctx.Abort(500, "Server Error")
-        }
-        if len(ret) == 0 {
-            return
-        }
+		ret, err := s.safelyCall(route.handler, args)
+		if err != nil {
+			//there was an error or panic while calling the handler
+			ctx.Abort(500, "Server Error")
+		}
+		if len(ret) == 0 {
+			return
+		}
 
-        sval := ret[0]
+		sval := ret[0]
 
-        var content []byte
+		var content []byte
 
-        if sval.Kind() == reflect.String {
-            content = []byte(sval.String())
-        } else if sval.Kind() == reflect.Slice && sval.Type().Elem().Kind() == reflect.Uint8 {
-            content = sval.Interface().([]byte)
-        }
-        ctx.SetHeader("Content-Length", strconv.Itoa(len(content)), true)
-        _, err = ctx.ResponseWriter.Write(content)
-        if err != nil {
-            ctx.Server.Logger.Println("Error during write: ", err)
-        }
-        return
-    }
+		if sval.Kind() == reflect.String {
+			content = []byte(sval.String())
+		} else if sval.Kind() == reflect.Slice && sval.Type().Elem().Kind() == reflect.Uint8 {
+			content = sval.Interface().([]byte)
+		}
+		ctx.SetHeader("Content-Length", strconv.Itoa(len(content)), true)
+		_, err = ctx.ResponseWriter.Write(content)
+		if err != nil {
+			ctx.Server.Logger.Println("Error during write: ", err)
+		}
+		return
+	}
 
-    // try serving index.html or index.htm
-    if req.Method == "GET" || req.Method == "HEAD" {
-        if s.tryServingFile(path.Join(requestPath, "index.html"), req, w) {
-            return
-        } else if s.tryServingFile(path.Join(requestPath, "index.htm"), req, w) {
-            return
-        }
-    }
-    ctx.Abort(404, "Page not found")
-    return
+	// try serving index.html or index.htm
+	if req.Method == "GET" || req.Method == "HEAD" {
+		if s.tryServingFile(path.Join(requestPath, "index.html"), req, w) {
+			return
+		} else if s.tryServingFile(path.Join(requestPath, "index.htm"), req, w) {
+			return
+		}
+	}
+	ctx.Abort(404, "Page not found")
+	return
 }
 
 // SetLogger sets the logger for server s
 func (s *Server) SetLogger(logger *log.Logger) {
-    s.Logger = logger
+	s.Logger = logger
 }

--- a/server.go
+++ b/server.go
@@ -281,10 +281,10 @@ func (s *Server) logRequest(ctx Context, sTime time.Time) {
         client = req.RemoteAddr
     }
 
-    fmt.Fprintf(&logEntry, "%s - \033[32;1m %s %s\033[0m - %v", client, req.Method, requestPath, duration)
+    fmt.Fprintf(&logEntry, "%s - %s %s - %v", client, req.Method, requestPath, duration)
 
     if len(ctx.Params) > 0 {
-        fmt.Fprintf(&logEntry, " - \033[37;1mParams: %v\033[0m\n", ctx.Params)
+        fmt.Fprintf(&logEntry, " - Params: %v\n", ctx.Params)
     }
 
     ctx.Server.Logger.Print(logEntry.String())

--- a/server.go
+++ b/server.go
@@ -138,6 +138,7 @@ func (s *Server) Run(addr string) {
 
     mux := http.NewServeMux()
     if s.Config.Profiler {
+        mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
         mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
         mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
         mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))


### PR DESCRIPTION
coloring in log output is not appearing correctly on windows cmd.exe.
Moreover for serious usages, logs will likely go to a file and at considerable frequency.
Instead of making the coloring to work on windows as well, disabling the coloring for all seems a better option.

fixes: https://github.com/hoisie/web/issues/137
