### PR TITLE
Reset Content-Type when doing route.httpHandler

### DIFF
--- a/server.go
+++ b/server.go
@@ -344,6 +344,8 @@ func (s *Server) routeHandler(req *http.Request, w http.ResponseWriter) (unused 
         }
 
         if route.httpHandler != nil {
+            // Reset Content-Type, or http.ServeFile would have wrong content type 
+            ctx.SetHeader("Content-Type", "", true)
             unused = &route
             // We can not handle custom http handlers here, give back to the caller.
             return


### PR DESCRIPTION
`http.ServeFile` tries to set file content type only if the `Content-Type` has not been set before.
If web.go does this setting in `web.Handler` funcs, web.go would have some issues when working with the other `net/http` based packages.