### PR TITLE
Fix 'serving' message displaying wrong address when using 0 as port

### DIFF
--- a/server.go
+++ b/server.go
@@ -145,12 +145,13 @@ func (s *Server) Run(addr string) {
     }
     mux.Handle("/", s)
 
-    s.Logger.Printf("web.go serving %s\n", addr)
-
     l, err := net.Listen("tcp", addr)
     if err != nil {
         log.Fatal("ListenAndServe:", err)
     }
+
+    s.Logger.Printf("web.go serving %s\n", l.Addr().String())
+
     s.l = l
     err = http.Serve(s.l, mux)
     s.l.Close()


### PR DESCRIPTION
When using zero as the port (to automatically choose port), the address in the "serving" message would also show zero as the port. This patch changes this to show the actual port in use.