### PR TITLE
replaced reference to deprecated code.google.com

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,22 +1,22 @@
 package web
 
 import (
-    "bytes"
-    "code.google.com/p/go.net/websocket"
-    "crypto/tls"
-    "fmt"
-    "log"
-    "net"
-    "net/http"
-    "net/http/pprof"
-    "os"
-    "path"
-    "reflect"
-    "regexp"
-    "runtime"
-    "strconv"
-    "strings"
-    "time"
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"golang.org/x/net/websocket"
+	"log"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"path"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // ServerConfig is configuration for server objects.

--- a/web.go
+++ b/web.go
@@ -4,7 +4,7 @@ package web
 
 import (
     "bytes"
-    "code.google.com/p/go.net/websocket"
+    "golang.org/x/net/websocket"
     "crypto/hmac"
     "crypto/sha1"
     "crypto/tls"


### PR DESCRIPTION
code.google.com is being deprecated and will no longer work with go get. The websocket library is now canonically hosted at golang.org/x/net/websocket.