### PR TITLE
Add the 'ColorOutput' server config option

### DIFF
--- a/server.go
+++ b/server.go
@@ -27,6 +27,7 @@ type ServerConfig struct {
 	CookieSecret string
 	RecoverPanic bool
 	Profiler     bool
+	ColorOutput  bool
 }
 
 // Server represents a web.go server.
@@ -284,10 +285,18 @@ func (s *Server) logRequest(ctx Context, sTime time.Time) {
 		client = req.RemoteAddr
 	}
 
-	fmt.Fprintf(&logEntry, "%s - \033[32;1m %s %s\033[0m - %v", client, req.Method, requestPath, duration)
+	if s.Config.ColorOutput {
+		fmt.Fprintf(&logEntry, "%s - \x1b[32;1m%s %s\x1b[0m - %v", client, req.Method, requestPath, duration)
+	} else {
+		fmt.Fprintf(&logEntry, "%s - %s %s - %v", client, req.Method, requestPath, duration)
+	}
 
 	if len(ctx.Params) > 0 {
-		fmt.Fprintf(&logEntry, " - \033[37;1mParams: %v\033[0m\n", ctx.Params)
+		if s.Config.ColorOutput {
+			fmt.Fprintf(&logEntry, " - \x1b[37;1mParams: %v\x1b[0m\n", ctx.Params)
+		} else {
+			fmt.Fprintf(&logEntry, " - Params: %v\n", ctx.Params)
+		}
 	}
 
 	ctx.Server.Logger.Print(logEntry.String())

--- a/web.go
+++ b/web.go
@@ -265,6 +265,7 @@ func SetLogger(logger *log.Logger) {
 // Config is the configuration of the main server.
 var Config = &ServerConfig{
 	RecoverPanic: true,
+	ColorOutput:  true,
 }
 
 var mainServer = NewServer()


### PR DESCRIPTION
When this option is set to true, the log output will contain color
escape sequences. Set it to false to disable color escape sequences.

Inspired by https://github.com/xyproto/web/commit/88b1a319e4f07943b0e4d3ac032862cd1aaf15c2

Resolves #153