### PR TITLE
Add check for 'Authorization' header in GetBasicAuth

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -91,9 +91,12 @@ func NewCookie(name string, value string, age int64) *http.Cookie {
 	return &http.Cookie{Name: name, Value: value, Expires: utctime}
 }
 
-// GetBasicAuth is a helper method of *Context that returns the decoded
-// user and password from the *Context's authorization header
+// GetBasicAuth returns the decoded user and password from the context's
+// 'Authorization' header.
 func (ctx *Context) GetBasicAuth() (string, string, error) {
+	if len(ctx.Request.Header["Authorization"]) == 0 {
+		return "", "", errors.New("No Authorization header provided")
+	}
 	authHeader := ctx.Request.Header["Authorization"][0]
 	authString := strings.Split(string(authHeader), " ")
 	if authString[0] != "Basic" {

--- a/web_test.go
+++ b/web_test.go
@@ -248,6 +248,7 @@ var tests = []Test{
 	{"POST", "/parsejson", map[string][]string{"Content-Type": {"application/json"}}, `{"a":"hello", "b":"world"}`, 200, "hello world"},
 	//{"GET", "/testenv", "", 200, "hello world"},
 	{"GET", "/authorization", map[string][]string{"Authorization": {BuildBasicAuthCredentials("foo", "bar")}}, "", 200, "foobar"},
+	{"GET", "/authorization", nil, "", 200, "fail"},
 }
 
 func buildTestRequest(method string, path string, body string, headers map[string][]string, cookies []*http.Cookie) *http.Request {


### PR DESCRIPTION
Previously, if the `Authorization` header was not provided, the method
would crash.  Add a check for the presence a header, and a test case
as well.

Resolves #174