### PR TITLE
Clean up the logic for color logging

### DIFF
--- a/ttycolors.go
+++ b/ttycolors.go
@@ -1,0 +1,30 @@
+package web
+
+import (
+	"golang.org/x/crypto/ssh/terminal"
+	"syscall"
+)
+
+var ttyCodes struct {
+	green string
+	white string
+	reset string
+}
+
+func init() {
+	ttyCodes.green = ttyBold("32")
+	ttyCodes.white = ttyBold("37")
+	ttyCodes.reset = ttyEscape("0")
+}
+
+func ttyBold(code string) string {
+	return ttyEscape("1;" + code)
+}
+
+func ttyEscape(code string) string {
+	if terminal.IsTerminal(syscall.Stdout) {
+		return "\x1b[" + code + "m"
+	} else {
+		return ""
+	}
+}


### PR DESCRIPTION
Previously, the escape sequences for terminal colors were included
directly in the log string. This made it difficult to understand what
was being logged. Add some wrapper methods to clean up the abstraction
of the color output logic. Also, avoid using color logging if web.go
isn't running in a terminal (e.g the output is being piped).