### PR TITLE
Switch secure cookie implementation

### DIFF
--- a/examples/secure_cookie.go
+++ b/examples/secure_cookie.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"github.com/hoisie/web"
+	"html"
+)
+
+var cookieName = "cookie"
+
+var notice = `
+<div>%v</div>
+`
+var form = `
+<form method="POST" action="update">
+  <div class="field">
+    <label for="cookie"> Set a cookie: </label>
+    <input id="cookie" name="cookie"> </input>
+  </div>
+
+  <input type="submit" value="Submit"></input>
+  <input type="submit" name="submit" value="Delete"></input>
+</form>
+`
+
+func index(ctx *web.Context) string {
+	cookie, ok := ctx.GetSecureCookie(cookieName)
+	var top string
+	if !ok {
+		top = fmt.Sprintf(notice, "The cookie has not been set")
+	} else {
+		var val = html.EscapeString(cookie)
+		top = fmt.Sprintf(notice, "The value of the cookie is '"+val+"'.")
+	}
+	return top + form
+}
+
+func update(ctx *web.Context) {
+	if ctx.Params["submit"] == "Delete" {
+		ctx.SetCookie(web.NewCookie(cookieName, "", -1))
+	} else {
+		ctx.SetSecureCookie(cookieName, ctx.Params["cookie"], 0)
+	}
+	ctx.Redirect(301, "/")
+}
+
+func main() {
+	web.Config.CookieSecret = "a long secure cookie secret"
+	web.Get("/", index)
+	web.Post("/update", update)
+	web.Run("0.0.0.0:9999")
+}

--- a/secure_cookie.go
+++ b/secure_cookie.go
@@ -1,0 +1,115 @@
+package web
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"errors"
+	"golang.org/x/crypto/pbkdf2"
+	"io"
+	"strings"
+)
+
+const (
+	pbkdf2Iterations = 64000
+	keySize          = 32
+)
+
+var (
+	ErrMissingCookieSecret = errors.New("Secret Key for secure cookies has not been set. Assign one to web.Config.CookieSecret.")
+	ErrInvalidKey          = errors.New("The keys for secure cookies have not been initialized. Ensure that a Run* method is being called")
+)
+
+func (ctx *Context) SetSecureCookie(name string, val string, age int64) error {
+	serverConfig := ctx.Server.Config
+	if len(serverConfig.CookieSecret) == 0 {
+		return ErrMissingCookieSecret
+	}
+
+	if len(serverConfig.encKey) == 0 || len(serverConfig.signKey) == 0 {
+		return ErrInvalidKey
+	}
+	ciphertext, err := encrypt([]byte(val), serverConfig.encKey)
+	if err != nil {
+		return err
+	}
+	sig := sign(ciphertext, serverConfig.signKey)
+	data := base64.StdEncoding.EncodeToString(ciphertext) + "|" + base64.StdEncoding.EncodeToString(sig)
+	ctx.SetCookie(NewCookie(name, data, age))
+	return nil
+}
+
+func (ctx *Context) GetSecureCookie(name string) (string, bool) {
+	for _, cookie := range ctx.Request.Cookies() {
+		if cookie.Name != name {
+			continue
+		}
+
+		parts := strings.SplitN(cookie.Value, "|", 2)
+		if len(parts) != 2 {
+			return "", false
+		}
+
+		ciphertext, err := base64.StdEncoding.DecodeString(parts[0])
+		if err != nil {
+			return "", false
+		}
+		sig, err := base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return "", false
+		}
+		expectedSig := sign([]byte(ciphertext), ctx.Server.Config.signKey)
+		if !bytes.Equal(expectedSig, sig) {
+			return "", false
+		}
+		plaintext, err := decrypt(ciphertext, ctx.Server.Config.encKey)
+		if err != nil {
+			return "", false
+		}
+		return string(plaintext), true
+	}
+	return "", false
+}
+
+func genKey(password string, salt string) []byte {
+	return pbkdf2.Key([]byte(password), []byte(salt), pbkdf2Iterations, keySize, sha512.New)
+}
+
+func encrypt(plaintext []byte, key []byte) ([]byte, error) {
+	aesCipher, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+	stream := cipher.NewCTR(aesCipher, iv)
+	stream.XORKeyStream(ciphertext[aes.BlockSize:], plaintext)
+	return ciphertext, nil
+}
+
+func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
+	if len(ciphertext) <= aes.BlockSize {
+		return nil, errors.New("Invalid cipher text")
+	}
+	aesCipher, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	plaintext := make([]byte, len(ciphertext)-aes.BlockSize)
+	stream := cipher.NewCTR(aesCipher, ciphertext[:aes.BlockSize])
+	stream.XORKeyStream(plaintext, ciphertext[aes.BlockSize:])
+	return plaintext, nil
+}
+
+func sign(data []byte, key []byte) []byte {
+	mac := hmac.New(sha512.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}

--- a/server.go
+++ b/server.go
@@ -28,6 +28,8 @@ type ServerConfig struct {
 	RecoverPanic bool
 	Profiler     bool
 	ColorOutput  bool
+	encKey       []byte
+	signKey      []byte
 }
 
 // Server represents a web.go server.
@@ -55,6 +57,12 @@ func (s *Server) initServer() {
 
 	if s.Logger == nil {
 		s.Logger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
+	}
+
+	if len(s.Config.CookieSecret) > 0 {
+		s.Logger.Println("Generating cookie encryption keys")
+		s.Config.encKey = genKey(s.Config.CookieSecret, "encryption key salt")
+		s.Config.signKey = genKey(s.Config.CookieSecret, "signature key salt")
 	}
 }
 

--- a/web_test.go
+++ b/web_test.go
@@ -487,6 +487,7 @@ func makeCookie(vals map[string]string) []*http.Cookie {
 
 func TestSecureCookie(t *testing.T) {
 	mainServer.Config.CookieSecret = "7C19QRmwf3mHZ9CPAaPQ0hsWeufKd"
+	mainServer.initServer()
 	resp1 := getTestResponse("POST", "/securecookie/set/a/1", "", nil, nil)
 	sval, ok := resp1.cookies["a"]
 	if !ok {


### PR DESCRIPTION
Previously, secure cookies in web.go were only cryptographically signed.
This prevented them from being tampered with. However, the contents of
the cookies were still transmitted in plain text to the client.

Instead of only signing the contents of the cookie, encrypt the contents
as well. This prevents any kind of information leakage.

Secure cookies are now encrypted with AES counter mode with a 32 bit
key. The contents are still signed using HMAC. Both the encryption key
and the signature key are generated using pbkdf2 using the CookieSecret
config option as the password source. The ciphertext, initialization
vector, and signature are now transmitted to the client.

Although the API is the same, cookies previously stored will not be
readable. Unfortunately there is no smooth upgrade process.

An example of using secure cookies has been added as well.

Fixes #160