### PR TITLE
Type casting the syscall.Stdout to int to fix Windows compilation

### DIFF
--- a/ttycolors.go
+++ b/ttycolors.go
@@ -22,7 +22,7 @@ func ttyBold(code string) string {
 }
 
 func ttyEscape(code string) string {
-	if terminal.IsTerminal(syscall.Stdout) {
+	if terminal.IsTerminal(int(syscall.Stdout)) {
 		return "\x1b[" + code + "m"
 	} else {
 		return ""


### PR DESCRIPTION
When building for Windows, people have been encountering the following error:

`../github.com/hoisie/web/ttycolors.go:28:25: cannot use syscall.Stdout (type syscall.Handle) as type int in argument to terminal.IsTerminal`

This is due to weird behavior where syscall.Stdout is not being cast as int. Casting this before passing it as an argument to terminal.isTerminal() fixes this problem. 